### PR TITLE
[issue#79](fix): update coverage

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,4 +2,4 @@
 testpaths = tests
 pythonpath = . back
 norecursedirs = .venv pytest-cache-files-* .pytest_cache
-addopts = -vv -ra -p no:cacheprovider --cov=back --cov-report=
+addopts = -vv -ra -p no:cacheprovider --cov=back/routers --cov-report=


### PR DESCRIPTION
Closes #79 
Теперь расчёт coverage (покрытия) реализованных командой тестов происходит относительно нужной директории (back/routers), а не всего back